### PR TITLE
allow installation to external media

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    android:installLocation="auto"
     package="fr.byped.bwarearea">
 
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />


### PR DESCRIPTION
This change will enable installation of the app to external as well as internal flash memory which is important for devices where internal memory is limited but external memory is cheap and abundant in form of micro SD cards. Thank you for your consideration.

More information at https://developer.android.com/guide/topics/data/install-location.